### PR TITLE
feat(darwin): manage Rectangle and Stats settings

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -3,7 +3,7 @@
 # macOS 전용 파일 (macOS가 아닌 경우 무시)
 .chezmoiscripts/darwin/**
 Brewfile
-dot_config/cmux/**
+.config/cmux/**
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -4,6 +4,7 @@
 .chezmoiscripts/darwin/**
 Brewfile
 .config/cmux/**
+.config/rectangle/**
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -5,6 +5,7 @@
 Brewfile
 .config/cmux/**
 .config/rectangle/**
+.config/stats/**
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}

--- a/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
@@ -35,6 +35,7 @@ if [ -f "$STATS_CONFIG" ]; then
     STATS_ACCESS_TOKEN="$(defaults read eu.exelban.Stats access_token 2>/dev/null || true)"
     STATS_REFRESH_TOKEN="$(defaults read eu.exelban.Stats refresh_token 2>/dev/null || true)"
 
+    killall Stats 2>/dev/null || true
     defaults import eu.exelban.Stats "$STATS_CONFIG"
 
     if [ -n "$STATS_REMOTE_ID" ]; then

--- a/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# App settings: Rectangle
+#
+# Rectangle config hash: {{ include "dot_config/rectangle/RectangleConfig.json" | sha256sum }}
+
+{{ if ne .chezmoi.os "darwin" }}
+exit 0
+{{ end }}
+
+set -eufo pipefail
+
+echo "[app-settings][start]"
+
+RECTANGLE_CONFIG="{{ .chezmoi.sourceDir }}/dot_config/rectangle/RectangleConfig.json"
+RECTANGLE_IMPORT="$HOME/Library/Application Support/Rectangle/RectangleConfig.json"
+
+# Rectangle
+# - Rectangle reads this file on next launch, then renames/removes it.
+if [ -f "$RECTANGLE_CONFIG" ]; then
+    echo "[app-settings][rectangle] stage import config"
+    mkdir -p "$(dirname "$RECTANGLE_IMPORT")"
+    install -m 0644 "$RECTANGLE_CONFIG" "$RECTANGLE_IMPORT"
+else
+    echo "[app-settings][warning] Rectangle config not found"
+fi
+
+echo "[app-settings][done]"

--- a/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
@@ -1,8 +1,9 @@
 #!/bin/bash
 #
-# App settings: Rectangle
+# App settings: Rectangle, Stats
 #
 # Rectangle config hash: {{ include "dot_config/rectangle/RectangleConfig.json" | sha256sum }}
+# Stats config hash: {{ include "dot_config/stats/Stats.plist" | sha256sum }}
 
 {{ if ne .chezmoi.os "darwin" }}
 exit 0
@@ -14,6 +15,7 @@ echo "[app-settings][start]"
 
 RECTANGLE_CONFIG="{{ .chezmoi.sourceDir }}/dot_config/rectangle/RectangleConfig.json"
 RECTANGLE_IMPORT="$HOME/Library/Application Support/Rectangle/RectangleConfig.json"
+STATS_CONFIG="{{ .chezmoi.sourceDir }}/dot_config/stats/Stats.plist"
 
 # Rectangle
 # - Rectangle reads this file on next launch, then renames/removes it.
@@ -23,6 +25,29 @@ if [ -f "$RECTANGLE_CONFIG" ]; then
     install -m 0644 "$RECTANGLE_CONFIG" "$RECTANGLE_IMPORT"
 else
     echo "[app-settings][warning] Rectangle config not found"
+fi
+
+# Stats
+# - Preserve remote credentials managed by the app, then import baseline settings.
+if [ -f "$STATS_CONFIG" ]; then
+    echo "[app-settings][stats] import defaults"
+    STATS_REMOTE_ID="$(defaults read eu.exelban.Stats remote_id 2>/dev/null || true)"
+    STATS_ACCESS_TOKEN="$(defaults read eu.exelban.Stats access_token 2>/dev/null || true)"
+    STATS_REFRESH_TOKEN="$(defaults read eu.exelban.Stats refresh_token 2>/dev/null || true)"
+
+    defaults import eu.exelban.Stats "$STATS_CONFIG"
+
+    if [ -n "$STATS_REMOTE_ID" ]; then
+        defaults write eu.exelban.Stats remote_id -string "$STATS_REMOTE_ID"
+    fi
+    if [ -n "$STATS_ACCESS_TOKEN" ]; then
+        defaults write eu.exelban.Stats access_token -string "$STATS_ACCESS_TOKEN"
+    fi
+    if [ -n "$STATS_REFRESH_TOKEN" ]; then
+        defaults write eu.exelban.Stats refresh_token -string "$STATS_REFRESH_TOKEN"
+    fi
+else
+    echo "[app-settings][warning] Stats config not found"
 fi
 
 echo "[app-settings][done]"

--- a/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl
@@ -13,9 +13,12 @@ set -eufo pipefail
 
 echo "[app-settings][start]"
 
-RECTANGLE_CONFIG="{{ .chezmoi.sourceDir }}/dot_config/rectangle/RectangleConfig.json"
+RECTANGLE_CONFIG="$HOME/.config/rectangle/RectangleConfig.json"
 RECTANGLE_IMPORT="$HOME/Library/Application Support/Rectangle/RectangleConfig.json"
-STATS_CONFIG="{{ .chezmoi.sourceDir }}/dot_config/stats/Stats.plist"
+STATS_CONFIG="$HOME/.config/stats/Stats.plist"
+STATS_TEMP_DIR=""
+
+trap 'if [ -n "$STATS_TEMP_DIR" ]; then rm -rf "$STATS_TEMP_DIR"; fi' EXIT
 
 # Rectangle
 # - Rectangle reads this file on next launch, then renames/removes it.
@@ -31,22 +34,31 @@ fi
 # - Preserve remote credentials managed by the app, then import baseline settings.
 if [ -f "$STATS_CONFIG" ]; then
     echo "[app-settings][stats] import defaults"
-    STATS_REMOTE_ID="$(defaults read eu.exelban.Stats remote_id 2>/dev/null || true)"
-    STATS_ACCESS_TOKEN="$(defaults read eu.exelban.Stats access_token 2>/dev/null || true)"
-    STATS_REFRESH_TOKEN="$(defaults read eu.exelban.Stats refresh_token 2>/dev/null || true)"
-
     killall Stats 2>/dev/null || true
-    defaults import eu.exelban.Stats "$STATS_CONFIG"
 
-    if [ -n "$STATS_REMOTE_ID" ]; then
-        defaults write eu.exelban.Stats remote_id -string "$STATS_REMOTE_ID"
+    STATS_TEMP_DIR="$(mktemp -d)"
+    chmod 0700 "$STATS_TEMP_DIR"
+    STATS_CURRENT_PLIST="$STATS_TEMP_DIR/current.plist"
+    STATS_IMPORT_PLIST="$STATS_TEMP_DIR/import.plist"
+    cp "$STATS_CONFIG" "$STATS_IMPORT_PLIST"
+    chmod 0600 "$STATS_IMPORT_PLIST"
+
+    if defaults export eu.exelban.Stats "$STATS_CURRENT_PLIST" 2>/dev/null; then
+        chmod 0600 "$STATS_CURRENT_PLIST"
+        for key in remote_id access_token refresh_token; do
+            key_file="$STATS_TEMP_DIR/$key"
+            if plutil -extract "$key" raw -expect string -o "$key_file" "$STATS_CURRENT_PLIST" 2>/dev/null; then
+                chmod 0600 "$key_file"
+                /usr/libexec/PlistBuddy -c "Delete :$key" "$STATS_IMPORT_PLIST" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c "Add :$key string" "$STATS_IMPORT_PLIST"
+                /usr/libexec/PlistBuddy -c "Import :$key \"$key_file\"" "$STATS_IMPORT_PLIST"
+            fi
+        done
     fi
-    if [ -n "$STATS_ACCESS_TOKEN" ]; then
-        defaults write eu.exelban.Stats access_token -string "$STATS_ACCESS_TOKEN"
-    fi
-    if [ -n "$STATS_REFRESH_TOKEN" ]; then
-        defaults write eu.exelban.Stats refresh_token -string "$STATS_REFRESH_TOKEN"
-    fi
+
+    defaults import eu.exelban.Stats "$STATS_IMPORT_PLIST"
+    rm -rf "$STATS_TEMP_DIR"
+    STATS_TEMP_DIR=""
 else
     echo "[app-settings][warning] Stats config not found"
 fi

--- a/home/dot_config/rectangle/RectangleConfig.json
+++ b/home/dot_config/rectangle/RectangleConfig.json
@@ -1,0 +1,329 @@
+{
+  "bundleId" : "com.knollsoft.Rectangle",
+  "defaults" : {
+    "SUEnableAutomaticChecks" : {
+      "bool" : true
+    },
+    "allowAnyShortcut" : {
+      "bool" : true
+    },
+    "almostMaximizeHeight" : {
+      "float" : 0
+    },
+    "almostMaximizeWidth" : {
+      "float" : 0
+    },
+    "altThirdCycle" : {
+      "int" : 0
+    },
+    "alternateDefaultShortcuts" : {
+      "bool" : false
+    },
+    "alwaysAccountForStage" : {
+      "int" : 0
+    },
+    "applyGapsToMaximize" : {
+      "int" : 0
+    },
+    "applyGapsToMaximizeHeight" : {
+      "int" : 0
+    },
+    "attemptMatchOnNextPrevDisplay" : {
+      "int" : 0
+    },
+    "autoMaximize" : {
+      "int" : 0
+    },
+    "cascadeAllDeltaSize" : {
+      "float" : 30
+    },
+    "centerHalfCycles" : {
+      "int" : 0
+    },
+    "centeredDirectionalMove" : {
+      "int" : 0
+    },
+    "cornerSnapAreaSize" : {
+      "float" : 20
+    },
+    "curtainChangeSize" : {
+      "int" : 0
+    },
+    "cycleSizesIsChanged" : {
+      "bool" : false
+    },
+    "disabledApps" : {
+
+    },
+    "doubleClickTitleBar" : {
+      "int" : 0
+    },
+    "doubleClickTitleBarIgnoredApps" : {
+
+    },
+    "doubleClickTitleBarRestore" : {
+      "int" : 0
+    },
+    "dragFromStage" : {
+      "int" : 0
+    },
+    "enhancedUI" : {
+      "int" : 1
+    },
+    "footprintAlpha" : {
+      "float" : 0.3
+    },
+    "footprintAnimationDurationMultiplier" : {
+      "float" : 0
+    },
+    "footprintBorderWidth" : {
+      "float" : 2
+    },
+    "footprintColor" : {
+
+    },
+    "footprintFade" : {
+      "int" : 0
+    },
+    "fullIgnoreBundleIds" : {
+
+    },
+    "gapSize" : {
+      "float" : 0
+    },
+    "hapticFeedbackOnSnap" : {
+      "int" : 0
+    },
+    "hideMenubarIcon" : {
+      "bool" : true
+    },
+    "horizontalSplitRatio" : {
+      "float" : 50
+    },
+    "ignoreDragSnapToo" : {
+      "int" : 0
+    },
+    "ignoredSnapAreas" : {
+      "int" : 0
+    },
+    "landscapeSnapAreas" : {
+      "string" : "null"
+    },
+    "launchOnLogin" : {
+      "bool" : true
+    },
+    "minimumWindowHeight" : {
+      "float" : 0
+    },
+    "minimumWindowWidth" : {
+      "float" : 0
+    },
+    "missionControlDragging" : {
+      "int" : 0
+    },
+    "missionControlDraggingAllowedOffscreenDistance" : {
+      "float" : 25
+    },
+    "missionControlDraggingDisallowedDuration" : {
+      "int" : 250
+    },
+    "moveCursor" : {
+      "int" : 0
+    },
+    "moveCursorAcrossDisplays" : {
+      "int" : 0
+    },
+    "notifiedOfProblemApps" : {
+      "bool" : false
+    },
+    "obtainWindowOnClick" : {
+      "int" : 0
+    },
+    "portraitSnapAreas" : {
+      "string" : "null"
+    },
+    "relaunchOpensMenu" : {
+      "bool" : false
+    },
+    "resizeOnDirectionalMove" : {
+      "bool" : false
+    },
+    "screenEdgeGapBottom" : {
+      "float" : 0
+    },
+    "screenEdgeGapLeft" : {
+      "float" : 0
+    },
+    "screenEdgeGapRight" : {
+      "float" : 0
+    },
+    "screenEdgeGapTop" : {
+      "float" : 0
+    },
+    "screenEdgeGapTopNotch" : {
+      "float" : 0
+    },
+    "screenEdgeGapsOnMainScreenOnly" : {
+      "bool" : false
+    },
+    "screensOrderedByX" : {
+      "int" : 0
+    },
+    "selectedCycleSizes" : {
+      "int" : 0
+    },
+    "shortEdgeSnapAreaSize" : {
+      "float" : 145
+    },
+    "showAdditionalSizesInMenu" : {
+      "int" : 0
+    },
+    "showAllActionsInMenu" : {
+      "int" : 0
+    },
+    "sixthsSnapArea" : {
+      "int" : 0
+    },
+    "sizeOffset" : {
+      "float" : 0
+    },
+    "snapEdgeMarginBottom" : {
+      "float" : 5
+    },
+    "snapEdgeMarginLeft" : {
+      "float" : 5
+    },
+    "snapEdgeMarginRight" : {
+      "float" : 5
+    },
+    "snapEdgeMarginTop" : {
+      "float" : 5
+    },
+    "snapModifiers" : {
+      "int" : 0
+    },
+    "specifiedHeight" : {
+      "float" : 1050
+    },
+    "specifiedWidth" : {
+      "float" : 1680
+    },
+    "stageSize" : {
+      "float" : 190
+    },
+    "subsequentExecutionMode" : {
+      "int" : 0
+    },
+    "systemWideMouseDown" : {
+      "int" : 0
+    },
+    "systemWideMouseDownApps" : {
+
+    },
+    "todo" : {
+      "int" : 0
+    },
+    "todoApplication" : {
+
+    },
+    "todoMode" : {
+      "bool" : false
+    },
+    "todoSidebarSide" : {
+      "int" : 1
+    },
+    "todoSidebarWidth" : {
+      "float" : 400
+    },
+    "traverseSingleScreen" : {
+      "int" : 0
+    },
+    "unsnapRestore" : {
+      "int" : 0
+    },
+    "verticalSplitRatio" : {
+      "float" : 50
+    },
+    "widthStepSize" : {
+      "float" : 30
+    },
+    "windowSnapping" : {
+      "int" : 2
+    }
+  },
+  "shortcuts" : {
+    "bottomHalf" : {
+      "keyCode" : 125,
+      "modifierFlags" : 1572864
+    },
+    "bottomLeft" : {
+      "keyCode" : 123,
+      "modifierFlags" : 1441792
+    },
+    "bottomRight" : {
+      "keyCode" : 124,
+      "modifierFlags" : 1441792
+    },
+    "center" : {
+      "keyCode" : 8,
+      "modifierFlags" : 1572864
+    },
+    "larger" : {
+      "keyCode" : 124,
+      "modifierFlags" : 917504
+    },
+    "leftHalf" : {
+      "keyCode" : 123,
+      "modifierFlags" : 1572864
+    },
+    "maximize" : {
+      "keyCode" : 3,
+      "modifierFlags" : 1572864
+    },
+    "maximizeHeight" : {
+      "keyCode" : 126,
+      "modifierFlags" : 917504
+    },
+    "nextDisplay" : {
+      "keyCode" : 124,
+      "modifierFlags" : 1835008
+    },
+    "previousDisplay" : {
+      "keyCode" : 123,
+      "modifierFlags" : 1835008
+    },
+    "reflowTodo" : {
+      "keyCode" : 45,
+      "modifierFlags" : 786432
+    },
+    "restore" : {
+      "keyCode" : 51,
+      "modifierFlags" : 786432
+    },
+    "rightHalf" : {
+      "keyCode" : 124,
+      "modifierFlags" : 1572864
+    },
+    "smaller" : {
+      "keyCode" : 123,
+      "modifierFlags" : 917504
+    },
+    "toggleTodo" : {
+      "keyCode" : 11,
+      "modifierFlags" : 786432
+    },
+    "topHalf" : {
+      "keyCode" : 126,
+      "modifierFlags" : 1572864
+    },
+    "topLeft" : {
+      "keyCode" : 123,
+      "modifierFlags" : 1310720
+    },
+    "topRight" : {
+      "keyCode" : 124,
+      "modifierFlags" : 1310720
+    }
+  },
+  "version" : "101"
+}

--- a/home/dot_config/stats/Stats.plist
+++ b/home/dot_config/stats/Stats.plist
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Battery_notifications_high</key>
+	<string></string>
+	<key>Battery_notifications_low</key>
+	<string>low</string>
+	<key>Battery_state</key>
+	<false/>
+	<key>CPU_state</key>
+	<false/>
+	<key>Disk_state</key>
+	<false/>
+	<key>LaunchAtLoginNext</key>
+	<true/>
+	<key>NSNavPanelExpandedSizeForOpenMode</key>
+	<string>{880, 448}</string>
+	<key>NSStatusItem Preferred Position Network_speed</key>
+	<real>348</real>
+	<key>NSStatusItem Preferred Position RAM_memory</key>
+	<real>270</real>
+	<key>NSStatusItem Preferred Position Sensors_sensors</key>
+	<real>228</real>
+	<key>NSToolbar Configuration eu.exelban.Stats.Settings.Toolbar</key>
+	<dict>
+		<key>TB Display Mode</key>
+		<integer>1</integer>
+		<key>TB Icon Size Mode</key>
+		<integer>1</integer>
+		<key>TB Is Shown</key>
+		<true/>
+		<key>TB Size Mode</key>
+		<integer>1</integer>
+	</dict>
+	<key>NSWindow Frame eu.exelban.Stats.Settings.WindowFrame</key>
+	<string>504 364 728 480 0 0 1728 1084 </string>
+	<key>Network_updateICMPInterval</key>
+	<integer>10</integer>
+	<key>RAM_barChart_position</key>
+	<integer>4</integer>
+	<key>RAM_label_position</key>
+	<integer>2</integer>
+	<key>RAM_lineChart_position</key>
+	<integer>3</integer>
+	<key>RAM_memory_position</key>
+	<integer>0</integer>
+	<key>RAM_mini_position</key>
+	<integer>1</integer>
+	<key>RAM_pieChart_position</key>
+	<integer>5</integer>
+	<key>RAM_state_position</key>
+	<integer>8</integer>
+	<key>RAM_tachometer_position</key>
+	<integer>6</integer>
+	<key>RAM_text_position</key>
+	<integer>7</integer>
+	<key>RAM_updateInterval</key>
+	<integer>10</integer>
+	<key>RAM_updateTopInterval</key>
+	<integer>10</integer>
+	<key>RAM_widget</key>
+	<string>memory</string>
+	<key>Sensors_barChart_position</key>
+	<integer>3</integer>
+	<key>Sensors_label_position</key>
+	<integer>2</integer>
+	<key>Sensors_mini_position</key>
+	<integer>1</integer>
+	<key>Sensors_sensors_alignment</key>
+	<string>center</string>
+	<key>Sensors_sensors_size</key>
+	<false/>
+	<key>Sensors_stack_position</key>
+	<integer>0</integer>
+	<key>Sensors_state</key>
+	<true/>
+	<key>Sensors_updateInterval</key>
+	<integer>10</integer>
+	<key>Sensors_widget</key>
+	<string>sensors</string>
+	<key>runAtLoginInitialized</key>
+	<true/>
+	<key>sensor_Average GPU</key>
+	<false/>
+	<key>sensor_Hottest CPU</key>
+	<true/>
+	<key>sensor_Hottest GPU</key>
+	<true/>
+	<key>sensor_PCI Power</key>
+	<false/>
+	<key>sensor_TB1T</key>
+	<false/>
+	<key>sensor_TB2T</key>
+	<false/>
+	<key>sensor_TW0P</key>
+	<false/>
+	<key>sensor_TaLP</key>
+	<false/>
+	<key>sensor_TaRF</key>
+	<false/>
+	<key>sensor_Tm02</key>
+	<false/>
+	<key>setupProcess</key>
+	<true/>
+	<key>support_ts</key>
+	<integer>1776942994</integer>
+	<key>updater_check_ts</key>
+	<integer>1776942994</integer>
+	<key>version</key>
+	<string>2.12.11</string>
+</dict>
+</plist>

--- a/tests/linux.sh
+++ b/tests/linux.sh
@@ -53,7 +53,8 @@ IGNORE_FAIL=0
 for target in \
     "Brewfile" \
     ".config/cmux/settings.json" \
-    ".config/rectangle/RectangleConfig.json"; do
+    ".config/rectangle/RectangleConfig.json" \
+    ".config/stats/Stats.plist"; do
     if printf '%s\n' "$MANAGED_PATHS" | grep -Fxq "$target"; then
         echo "    FAIL: $target is managed on Linux"
         IGNORE_FAIL=$((IGNORE_FAIL + 1))

--- a/tests/linux.sh
+++ b/tests/linux.sh
@@ -52,7 +52,8 @@ MANAGED_PATHS="$(chezmoi managed --include=files 2>/dev/null || true)"
 IGNORE_FAIL=0
 for target in \
     "Brewfile" \
-    ".config/cmux/settings.json"; do
+    ".config/cmux/settings.json" \
+    ".config/rectangle/RectangleConfig.json"; do
     if printf '%s\n' "$MANAGED_PATHS" | grep -Fxq "$target"; then
         echo "    FAIL: $target is managed on Linux"
         IGNORE_FAIL=$((IGNORE_FAIL + 1))

--- a/tests/linux.sh
+++ b/tests/linux.sh
@@ -46,6 +46,25 @@ else
     fail "$TMPL_FAIL template(s) failed to render"
 fi
 
+# --- 2.2. OS별 ignore 검증 ---
+section "OS-specific ignores"
+MANAGED_PATHS="$(chezmoi managed --include=files 2>/dev/null || true)"
+IGNORE_FAIL=0
+for target in \
+    "Brewfile" \
+    ".config/cmux/settings.json"; do
+    if printf '%s\n' "$MANAGED_PATHS" | grep -Fxq "$target"; then
+        echo "    FAIL: $target is managed on Linux"
+        IGNORE_FAIL=$((IGNORE_FAIL + 1))
+    fi
+done
+
+if [ "$IGNORE_FAIL" -eq 0 ]; then
+    pass "macOS-only files are ignored on Linux"
+else
+    fail "$IGNORE_FAIL macOS-only file(s) managed on Linux"
+fi
+
 # --- 2.5. Zsh 설정 회귀 검증 ---
 section "Zsh config regression"
 if bash "$HOME/tests/zsh-config.sh"; then

--- a/tests/macos.sh
+++ b/tests/macos.sh
@@ -97,6 +97,7 @@ section "macOS app settings automation"
 RECTANGLE_CONFIG_SOURCE="$REPO_DIR/home/dot_config/rectangle/RectangleConfig.json"
 STATS_CONFIG_SOURCE="$REPO_DIR/home/dot_config/stats/Stats.plist"
 APP_SETTINGS_SCRIPT_SOURCE="$REPO_DIR/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl"
+STATS_EXCLUDED_KEYS='NSOSPLastRootDirectory|remote_id|access_token|refresh_token'
 
 if [ ! -f "$RECTANGLE_CONFIG_SOURCE" ]; then
     fail "Rectangle config source is missing"
@@ -115,7 +116,7 @@ else
 fi
 
 if [ -f "$STATS_CONFIG_SOURCE" ] \
-   && ! plutil -p "$STATS_CONFIG_SOURCE" | grep -Eq 'NSOSPLastRootDirectory|remote_id|access_token|refresh_token'; then
+   && ! plutil -p "$STATS_CONFIG_SOURCE" | grep -Eq "$STATS_EXCLUDED_KEYS"; then
     pass "Stats plist excludes file dialog state and remote credentials"
 else
     fail "Stats plist contains file dialog state or remote credentials"
@@ -128,7 +129,10 @@ if [ -f "$APP_SETTINGS_SCRIPT_SOURCE" ] \
    && bash -n "$rendered_app_script" \
    && grep -q 'Application Support/Rectangle/RectangleConfig.json' "$rendered_app_script" \
    && grep -q 'defaults import eu.exelban.Stats' "$rendered_app_script" \
-   && grep -q 'remote_id' "$rendered_app_script"; then
+   && grep -q 'PlistBuddy' "$rendered_app_script" \
+   && grep -q 'remote_id' "$rendered_app_script" \
+   && ! grep -q 'defaults write eu.exelban.Stats .*access_token' "$rendered_app_script" \
+   && ! grep -q 'defaults write eu.exelban.Stats .*refresh_token' "$rendered_app_script"; then
     pass "app settings darwin script imports Rectangle and Stats settings"
 else
     fail "app settings darwin script is missing or incomplete (stderr: $(cat "$app_script_err"))"

--- a/tests/macos.sh
+++ b/tests/macos.sh
@@ -95,6 +95,7 @@ rm -f "$rendered_cmux_script" "$cmux_script_err"
 # --- 1.3. macOS 앱 설정 자동 적용 검증 ---
 section "macOS app settings automation"
 RECTANGLE_CONFIG_SOURCE="$REPO_DIR/home/dot_config/rectangle/RectangleConfig.json"
+STATS_CONFIG_SOURCE="$REPO_DIR/home/dot_config/stats/Stats.plist"
 APP_SETTINGS_SCRIPT_SOURCE="$REPO_DIR/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl"
 
 if [ ! -f "$RECTANGLE_CONFIG_SOURCE" ]; then
@@ -107,15 +108,30 @@ else
     fail "Rectangle config JSON is invalid"
 fi
 
+if [ -f "$STATS_CONFIG_SOURCE" ] && plutil -lint "$STATS_CONFIG_SOURCE" >/dev/null 2>&1; then
+    pass "Stats plist is valid"
+else
+    fail "Stats plist is missing or invalid"
+fi
+
+if [ -f "$STATS_CONFIG_SOURCE" ] \
+   && ! plutil -p "$STATS_CONFIG_SOURCE" | grep -Eq 'NSOSPLastRootDirectory|remote_id|access_token|refresh_token'; then
+    pass "Stats plist excludes file dialog state and remote credentials"
+else
+    fail "Stats plist contains file dialog state or remote credentials"
+fi
+
 rendered_app_script="$(mktemp -p "$TMPHOME")"
 app_script_err="$(mktemp -p "$TMPHOME")"
 if [ -f "$APP_SETTINGS_SCRIPT_SOURCE" ] \
    && cz execute-template < "$APP_SETTINGS_SCRIPT_SOURCE" > "$rendered_app_script" 2>"$app_script_err" \
    && bash -n "$rendered_app_script" \
-   && grep -q 'Application Support/Rectangle/RectangleConfig.json' "$rendered_app_script"; then
-    pass "app settings darwin script imports Rectangle settings"
+   && grep -q 'Application Support/Rectangle/RectangleConfig.json' "$rendered_app_script" \
+   && grep -q 'defaults import eu.exelban.Stats' "$rendered_app_script" \
+   && grep -q 'remote_id' "$rendered_app_script"; then
+    pass "app settings darwin script imports Rectangle and Stats settings"
 else
-    fail "app settings darwin script is missing Rectangle import (stderr: $(cat "$app_script_err"))"
+    fail "app settings darwin script is missing or incomplete (stderr: $(cat "$app_script_err"))"
 fi
 rm -f "$rendered_app_script" "$app_script_err"
 

--- a/tests/macos.sh
+++ b/tests/macos.sh
@@ -92,6 +92,33 @@ else
 fi
 rm -f "$rendered_cmux_script" "$cmux_script_err"
 
+# --- 1.3. macOS 앱 설정 자동 적용 검증 ---
+section "macOS app settings automation"
+RECTANGLE_CONFIG_SOURCE="$REPO_DIR/home/dot_config/rectangle/RectangleConfig.json"
+APP_SETTINGS_SCRIPT_SOURCE="$REPO_DIR/home/.chezmoiscripts/darwin/run_onchange_after_05-app-settings.sh.tmpl"
+
+if [ ! -f "$RECTANGLE_CONFIG_SOURCE" ]; then
+    fail "Rectangle config source is missing"
+elif ! command -v jq &>/dev/null; then
+    warn "jq not installed, skipping Rectangle JSON validation"
+elif jq empty "$RECTANGLE_CONFIG_SOURCE" >/dev/null 2>&1; then
+    pass "Rectangle config JSON is valid"
+else
+    fail "Rectangle config JSON is invalid"
+fi
+
+rendered_app_script="$(mktemp -p "$TMPHOME")"
+app_script_err="$(mktemp -p "$TMPHOME")"
+if [ -f "$APP_SETTINGS_SCRIPT_SOURCE" ] \
+   && cz execute-template < "$APP_SETTINGS_SCRIPT_SOURCE" > "$rendered_app_script" 2>"$app_script_err" \
+   && bash -n "$rendered_app_script" \
+   && grep -q 'Application Support/Rectangle/RectangleConfig.json' "$rendered_app_script"; then
+    pass "app settings darwin script imports Rectangle settings"
+else
+    fail "app settings darwin script is missing Rectangle import (stderr: $(cat "$app_script_err"))"
+fi
+rm -f "$rendered_app_script" "$app_script_err"
+
 # --- 1.5. Zsh 설정 회귀 검증 ---
 section "Zsh config regression"
 if bash "$REPO_DIR/tests/zsh-config.sh"; then


### PR DESCRIPTION
## Summary
- add chezmoi-managed Rectangle config and stage it for Rectangle import on macOS
- add chezmoi-managed Stats plist and import it while preserving app-managed remote credential keys
- ignore macOS-only cmux, Rectangle, and Stats targets on non-Darwin systems and extend app settings coverage in the test scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS app settings automation to import/manage Rectangle and Stats configurations.
  * Included configuration files for Rectangle window management and Stats monitoring.

* **Tests**
  * Added macOS app-settings validation and a Linux check to ensure macOS-only configs are excluded.

* **Chores**
  * Updated ignore patterns to properly exclude macOS-specific application configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->