### PR TITLE
feat(chezmoi): add tokscale scheduled submit

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -30,10 +30,14 @@
 {{-   end -}}
 {{- end -}}
 
-{{/* 대화형 터미널에서 이름/이메일 입력 프롬프트 (최초 1회) */}}
+{{/* 기기 이름 기본값 (호스트네임) — tokscale 등 식별용, 초기 설정 시 입력으로 덮어씀 */}}
+{{- $deviceName := $hostname -}}
+
+{{/* 대화형 터미널에서 이름/이메일/기기명 입력 프롬프트 (최초 1회) */}}
 {{- if stdinIsATTY -}}
 {{-   $name = promptStringOnce . "name" "Full name" -}}
 {{-   $email = promptStringOnce . "email" "Email address" -}}
+{{-   $deviceName = promptStringOnce . "deviceName" "Device name (tokscale 식별용)" $hostname -}}
 {{- end -}}
 
 # chezmoi 소스 디렉토리 경로
@@ -44,5 +48,6 @@ sourceDir = {{ .chezmoi.sourceDir | quote }}
     name = {{ $name | quote }}
     email = {{ $email | quote }}
     hostname = {{ $hostname | quote }}
+    deviceName = {{ $deviceName | quote }}
     isAppleSilicon = {{ $isAppleSilicon }}
     homebrewPrefix = {{ $homebrewPrefix | quote }}

--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -6,6 +6,8 @@ Brewfile
 .config/cmux/**
 .config/rectangle/**
 .config/stats/**
+.config/tokscale/**
+Library/LaunchAgents/**
 {{ end }}
 
 {{ if ne .chezmoi.os "linux" }}

--- a/home/.chezmoiscripts/darwin/run_once_after_99-manual-install.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_once_after_99-manual-install.sh.tmpl
@@ -11,4 +11,8 @@ exit 0
 echo "[manual-install] the following apps require manual installation:"
 echo "  - JetBrains Toolbox: https://www.jetbrains.com/toolbox-app/"
 echo "  - Raycast: https://www.raycast.com/"
+
+# tokscale: 자동 submit(4일마다 14:00 KST) 전 최초 1회 로그인 필요
+echo "[manual-install] tokscale: run once to enable scheduled submit:"
+echo "  - bunx tokscale@latest login"
 echo "[manual-install] done"

--- a/home/.chezmoiscripts/darwin/run_onchange_after_07-tokscale-launchd.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_07-tokscale-launchd.sh.tmpl
@@ -16,6 +16,7 @@ echo "[tokscale-launchd][start]"
 uid="$(id -u)"
 label="ai.tokscale.submit"
 plist="$HOME/Library/LaunchAgents/${label}.plist"
+wrapper="$HOME/.config/tokscale/submit.sh"
 
 if [ ! -f "$plist" ]; then
     echo "[tokscale-launchd][warning] plist not found: $plist"
@@ -23,13 +24,24 @@ if [ ! -f "$plist" ]; then
     exit 0
 fi
 
-# 기존 등록 해제 후 재등록 (멱등)
+# 교체 전 검증: 잘못된 plist/래퍼면 기존(정상) 잡을 내리기 전에 즉시 실패시킨다
+if ! plutil -lint "$plist" >/dev/null; then
+    echo "[tokscale-launchd][error] invalid plist: $plist" >&2
+    exit 1
+fi
+if [ ! -x "$wrapper" ]; then
+    echo "[tokscale-launchd][error] submit wrapper missing or not executable: $wrapper" >&2
+    exit 1
+fi
+
+# 기존 등록 해제 후 재등록 (멱등). bootstrap 실패는 예약 작업 부재를 뜻하므로 실패로 surface
 launchctl bootout "gui/${uid}/${label}" 2>/dev/null || true
 if launchctl bootstrap "gui/${uid}" "$plist"; then
     launchctl enable "gui/${uid}/${label}" 2>/dev/null || true
     echo "[tokscale-launchd] (re)loaded ${label}"
 else
-    echo "[tokscale-launchd][warning] bootstrap failed for ${label}"
+    echo "[tokscale-launchd][error] bootstrap failed for ${label}" >&2
+    exit 1
 fi
 
 echo "[tokscale-launchd][done]"

--- a/home/.chezmoiscripts/darwin/run_onchange_after_07-tokscale-launchd.sh.tmpl
+++ b/home/.chezmoiscripts/darwin/run_onchange_after_07-tokscale-launchd.sh.tmpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# tokscale launchd LaunchAgent 등록/갱신 (4일마다 14:00 KST submit)
+#
+# plist hash: {{ include "Library/LaunchAgents/ai.tokscale.submit.plist.tmpl" | sha256sum }}
+# submit hash: {{ include "dot_config/tokscale/executable_submit.sh.tmpl" | sha256sum }}
+
+{{ if ne .chezmoi.os "darwin" }}
+exit 0
+{{ end }}
+
+set -eufo pipefail
+
+echo "[tokscale-launchd][start]"
+
+uid="$(id -u)"
+label="ai.tokscale.submit"
+plist="$HOME/Library/LaunchAgents/${label}.plist"
+
+if [ ! -f "$plist" ]; then
+    echo "[tokscale-launchd][warning] plist not found: $plist"
+    echo "[tokscale-launchd][done]"
+    exit 0
+fi
+
+# 기존 등록 해제 후 재등록 (멱등)
+launchctl bootout "gui/${uid}/${label}" 2>/dev/null || true
+if launchctl bootstrap "gui/${uid}" "$plist"; then
+    launchctl enable "gui/${uid}/${label}" 2>/dev/null || true
+    echo "[tokscale-launchd] (re)loaded ${label}"
+else
+    echo "[tokscale-launchd][warning] bootstrap failed for ${label}"
+fi
+
+echo "[tokscale-launchd][done]"

--- a/home/Library/LaunchAgents/ai.tokscale.submit.plist.tmpl
+++ b/home/Library/LaunchAgents/ai.tokscale.submit.plist.tmpl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.tokscale.submit</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{{ .chezmoi.homeDir }}/.config/tokscale/submit.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>14</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/tokscale-submit.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/tokscale-submit.log</string>
+</dict>
+</plist>

--- a/home/Library/LaunchAgents/ai.tokscale.submit.plist.tmpl
+++ b/home/Library/LaunchAgents/ai.tokscale.submit.plist.tmpl
@@ -9,6 +9,7 @@
         <string>/bin/bash</string>
         <string>{{ .chezmoi.homeDir }}/.config/tokscale/submit.sh</string>
     </array>
+    <!-- 발화 시각은 시스템 로컬 타임존 기준(launchd에 TZ 키 없음). 시스템 TZ=Asia/Seoul 전제로 KST 14:00 -->
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>

--- a/home/dot_claude/settings.json.tmpl
+++ b/home/dot_claude/settings.json.tmpl
@@ -1,7 +1,7 @@
 {{- /* ~/.claude/settings.json — Claude Code 핵심 설정 (권한, 플러그인, 훅) */ -}}
 {
   "respectGitignore": true,
-  "cleanupPeriodDays": 21,
+  "cleanupPeriodDays": 28,
   "attribution": {
     "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",
     "pr": ""

--- a/home/dot_config/tokscale/executable_submit.sh.tmpl
+++ b/home/dot_config/tokscale/executable_submit.sh.tmpl
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# tokscale 자동 submit 래퍼 (launchd: ai.tokscale.submit 에서 호출)
+#
+# - launchd가 매일 14:00(KST) 발화 → 마지막 성공으로부터 4일 미만이면 skip
+# - 절전/종료로 14:00을 놓치면 launchd가 다음 기상 시 보정 실행
+{{- $deviceName := get . "deviceName" | default (get . "hostname") | default .chezmoi.hostname }}
+# - 기기명: {{ $deviceName }}
+
+export TZ="Asia/Seoul"
+# launchd는 로그인 셸 PATH를 상속하지 않으므로 명시한다 (bun/bunx 포함)
+export PATH="$HOME/.bun/bin:{{ .homebrewPrefix }}/bin:/usr/local/bin:/usr/bin:/bin"
+
+DEVICE_NAME="$(cat <<'TOKSCALE_DEVICE_NAME_EOF'
+{{ $deviceName }}
+TOKSCALE_DEVICE_NAME_EOF
+)"
+export TOKSCALE_DEVICE_NAME="$DEVICE_NAME"
+STATE_DIR="$HOME/.local/state/tokscale"
+STAMP="$STATE_DIR/last-submit-epoch"
+LOG="$HOME/Library/Logs/tokscale-submit.log"
+INTERVAL=$((4 * 24 * 60 * 60)) # 4일
+SLACK=7200                     # 경계 jitter 여유 2시간
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")"
+
+log() {
+    printf '%s [%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" "$DEVICE_NAME" "$1" >>"$LOG"
+}
+
+now="$(date +%s)"
+
+# 4일 게이트 (스탬프 없으면 즉시 허용)
+if [ -f "$STAMP" ]; then
+    last="$(cat "$STAMP" 2>/dev/null || echo 0)"
+    case "$last" in *[!0-9]* | '') last=0 ;; esac
+    elapsed=$((now - last))
+    if [ "$elapsed" -lt $((INTERVAL - SLACK)) ]; then
+        log "skip: 마지막 submit 후 $((elapsed / 3600))시간 경과 (4일 미만)"
+        exit 0
+    fi
+fi
+
+# 인증 확인 (login 1회 또는 env 토큰)
+if [ ! -f "$HOME/.config/tokscale/credentials.json" ] && [ -z "${TOKSCALE_API_TOKEN:-}" ]; then
+    log "skip: 인증 없음 — 'bunx tokscale@latest login' 1회 실행 필요"
+    exit 0
+fi
+
+# bunx 확인
+if ! command -v bunx >/dev/null 2>&1; then
+    log "skip: bunx 없음 — bun 설치 확인 필요"
+    exit 0
+fi
+
+log "submit 시작"
+if bunx tokscale@latest submit </dev/null >>"$LOG" 2>&1; then
+    printf '%s\n' "$now" >"$STAMP"
+    log "submit 성공"
+else
+    log "submit 실패 (다음 14:00 재시도)"
+fi
+exit 0

--- a/home/dot_config/tokscale/executable_submit.sh.tmpl
+++ b/home/dot_config/tokscale/executable_submit.sh.tmpl
@@ -2,7 +2,7 @@
 #
 # tokscale 자동 submit 래퍼 (launchd: ai.tokscale.submit 에서 호출)
 #
-# - launchd가 매일 14:00(KST) 발화 → 마지막 성공으로부터 4일 미만이면 skip
+# - launchd가 매일 14:00에 발화(시스템 로컬 시각; 시스템 TZ=Asia/Seoul 전제로 KST 14:00) → 마지막 성공 후 4일 미만이면 skip
 # - 절전/종료로 14:00을 놓치면 launchd가 다음 기상 시 보정 실행
 {{- $deviceName := get . "deviceName" | default (get . "hostname") | default .chezmoi.hostname }}
 # - 기기명: {{ $deviceName }}
@@ -41,7 +41,8 @@ if [ -f "$STAMP" ]; then
     fi
 fi
 
-# 인증 확인 (login 1회 또는 env 토큰)
+# 인증 확인: launchd는 셸 프로필 env를 상속하지 않으므로 credentials.json(= tokscale login)이
+# 예약 실행의 신뢰 인증 경로다. TOKSCALE_API_TOKEN은 수동 실행/plist 주입 시에만 유효.
 if [ ! -f "$HOME/.config/tokscale/credentials.json" ] && [ -z "${TOKSCALE_API_TOKEN:-}" ]; then
     log "skip: 인증 없음 — 'bunx tokscale@latest login' 1회 실행 필요"
     exit 0

--- a/tests/linux.sh
+++ b/tests/linux.sh
@@ -54,7 +54,9 @@ for target in \
     "Brewfile" \
     ".config/cmux/settings.json" \
     ".config/rectangle/RectangleConfig.json" \
-    ".config/stats/Stats.plist"; do
+    ".config/stats/Stats.plist" \
+    ".config/tokscale/submit.sh" \
+    "Library/LaunchAgents/ai.tokscale.submit.plist"; do
     if printf '%s\n' "$MANAGED_PATHS" | grep -Fxq "$target"; then
         echo "    FAIL: $target is managed on Linux"
         IGNORE_FAIL=$((IGNORE_FAIL + 1))

--- a/tests/macos.sh
+++ b/tests/macos.sh
@@ -242,7 +242,35 @@ else
 fi
 rm -f "$rendered_brew_script" "$brew_script_err"
 
-# --- 1.8. Zsh 설정 회귀 검증 ---
+# --- 1.8. tokscale launchd 통합 검증 ---
+section "tokscale launchd integration"
+TOKSCALE_SUBMIT_SOURCE="$REPO_DIR/home/dot_config/tokscale/executable_submit.sh.tmpl"
+TOKSCALE_PLIST_SOURCE="$REPO_DIR/home/Library/LaunchAgents/ai.tokscale.submit.plist.tmpl"
+TOKSCALE_LAUNCHD_SOURCE="$REPO_DIR/home/.chezmoiscripts/darwin/run_onchange_after_07-tokscale-launchd.sh.tmpl"
+rendered_tokscale_submit="$(mktemp -p "$TMPHOME")"
+rendered_tokscale_plist="$(mktemp -p "$TMPHOME")"
+rendered_tokscale_launchd="$(mktemp -p "$TMPHOME")"
+tokscale_err="$(mktemp -p "$TMPHOME")"
+if cz execute-template < "$TOKSCALE_SUBMIT_SOURCE" > "$rendered_tokscale_submit" 2>"$tokscale_err" \
+   && bash -n "$rendered_tokscale_submit" \
+   && grep -Fq 'default .chezmoi.hostname' "$TOKSCALE_SUBMIT_SOURCE" \
+   && grep -Fq 'export TZ="Asia/Seoul"' "$rendered_tokscale_submit" \
+   && grep -Fq 'bunx tokscale@latest submit </dev/null' "$rendered_tokscale_submit" \
+   && cz execute-template < "$TOKSCALE_PLIST_SOURCE" > "$rendered_tokscale_plist" 2>>"$tokscale_err" \
+   && plutil -lint "$rendered_tokscale_plist" >/dev/null 2>&1 \
+   && grep -Fq '<integer>14</integer>' "$rendered_tokscale_plist" \
+   && cz execute-template < "$TOKSCALE_LAUNCHD_SOURCE" > "$rendered_tokscale_launchd" 2>>"$tokscale_err" \
+   && bash -n "$rendered_tokscale_launchd" \
+   && grep -Fq 'launchctl bootstrap "gui/${uid}" "$plist"' "$rendered_tokscale_launchd" \
+   && [ "$(cz target-path "$TOKSCALE_SUBMIT_SOURCE" 2>/dev/null)" = "$TMPHOME/.config/tokscale/submit.sh" ] \
+   && [ "$(cz target-path "$TOKSCALE_PLIST_SOURCE" 2>/dev/null)" = "$TMPHOME/Library/LaunchAgents/ai.tokscale.submit.plist" ]; then
+    pass "tokscale submit wrapper and LaunchAgent are managed safely"
+else
+    fail "tokscale launchd integration regression (stderr: $(cat "$tokscale_err"))"
+fi
+rm -f "$rendered_tokscale_submit" "$rendered_tokscale_plist" "$rendered_tokscale_launchd" "$tokscale_err"
+
+# --- 1.9. Zsh 설정 회귀 검증 ---
 section "Zsh config regression"
 if bash "$REPO_DIR/tests/zsh-config.sh"; then
     pass "Zsh config regression checks"

--- a/tests/macos.sh
+++ b/tests/macos.sh
@@ -263,7 +263,8 @@ if cz execute-template < "$TOKSCALE_SUBMIT_SOURCE" > "$rendered_tokscale_submit"
    && bash -n "$rendered_tokscale_launchd" \
    && grep -Fq 'launchctl bootstrap "gui/${uid}" "$plist"' "$rendered_tokscale_launchd" \
    && [ "$(cz target-path "$TOKSCALE_SUBMIT_SOURCE" 2>/dev/null)" = "$TMPHOME/.config/tokscale/submit.sh" ] \
-   && [ "$(cz target-path "$TOKSCALE_PLIST_SOURCE" 2>/dev/null)" = "$TMPHOME/Library/LaunchAgents/ai.tokscale.submit.plist" ]; then
+   && [ "$(cz target-path "$TOKSCALE_PLIST_SOURCE" 2>/dev/null)" = "$TMPHOME/Library/LaunchAgents/ai.tokscale.submit.plist" ] \
+   && [ "$(cz target-path "$TOKSCALE_LAUNCHD_SOURCE" 2>/dev/null)" = "$TMPHOME/.chezmoiscripts/darwin/07-tokscale-launchd.sh" ]; then
     pass "tokscale submit wrapper and LaunchAgent are managed safely"
 else
     fail "tokscale launchd integration regression (stderr: $(cat "$tokscale_err"))"


### PR DESCRIPTION
## Summary
- add macOS launchd scheduled ToksScale submit
- add chezmoi wiring and login reminder
- cover macOS/Linux checks

## Checks
- DOCKER_CONFIG=/private/tmp/dotfiles-docker-config make check
- git diff --check main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled macOS background job to run daily at 2:00 PM.
  * Added a one-time, interactive setup prompt for an optional device name (with hostname default) and made it available to downstream configuration.
* **Bug Fixes**
  * Improved launch automation to refresh the job reliably after updates.
  * Added safeguards to skip scheduled runs when credentials or required tooling aren’t available.
  * Updated cleanup retention to 28 days and extended platform ignore handling for new macOS files.
* **Tests**
  * Expanded macOS and Linux checks to validate the new launch templates and rendered outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->